### PR TITLE
Arduino.h import is causing some type conflicts 

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,12 +1,12 @@
 name=NDEF-MFRC522
-version=2.1.0
+version=2.1.1
 author=Aaron Roller<aaron.roller@aawhere.com>,Don Coleman <don.coleman@gmail.com>
 maintainer=Aaron Roller <aaron.roller@aawhere.com> 
 license=BSD License
 sentence=An Arduino/Particle library for NFC Data Exchange Format (NDEF).
 paragraph=Read and write NDEF messages to NFC tags and peers. Supports Mifare Ultralight with MFRC522 RFID board.
 category=Communication
-url=https://github.com/aroller/NDEF-MFRC522/releases/tag/2.1.0
+url=https://github.com/aroller/NDEF-MFRC522/releases/tag/2.1.1
 repository=https://github.com/aroller/NDEF-MFRC522.git
 dependencies=MFRC522
 architectures=avr,particle-xenon,particle-argon,particle-boron

--- a/src/Ndef.h
+++ b/src/Ndef.h
@@ -2,15 +2,14 @@
 #define Ndef_h
 
 // To save memory and stop serial output comment out the next line
-#define NDEF_USE_SERIAL
+//#define NDEF_USE_SERIAL
 
 /* NOTE: To use the Ndef library in your code, don't include Ndef.h
    See README.md for details on which files to include in your sketch.
 */
-
-#include <Arduino.h>
-
+// particle has conflicts so import Arduino.h only if needed
 #ifdef NDEF_USE_SERIAL
+#include <Arduino.h>
 void PrintHex(const byte *data, const long numBytes);
 void PrintHexChar(const byte *data, const long numBytes);
 void DumpHex(const byte *data, const long numBytes, const int blockSize);

--- a/src/NdefMessage.cpp
+++ b/src/NdefMessage.cpp
@@ -4,13 +4,6 @@ namespace ndef_mfrc522 {
 NdefMessage::NdefMessage(void) { _recordCount = 0; }
 
 NdefMessage::NdefMessage(const byte *data, const int numBytes) {
-#ifdef NDEF_DEBUG
-  Serial.print(F("Decoding "));
-  Serial.print(numBytes);
-  Serial.println(F(" bytes"));
-  PrintHexChar(data, numBytes);
-// DumpHex(data, numBytes, 16);
-#endif
 
   _recordCount = 0;
 
@@ -234,5 +227,5 @@ void NdefMessage::print() {
     _records[i].print();
   }
 }
-}
 #endif
+} // namespace ndef_mfrc522

--- a/src/NdefRecord.cpp
+++ b/src/NdefRecord.cpp
@@ -306,5 +306,5 @@ void NdefRecord::print() {
   Serial.print(getEncodedSize());
   Serial.println(" bytes");
 }
-} // end namespace
 #endif
+} // namespace ndef_mfrc522

--- a/src/NfcTag.cpp
+++ b/src/NfcTag.cpp
@@ -95,5 +95,5 @@ void NfcTag::print() {
     _ndefMessage->print();
   }
 }
-} // end namespace
 #endif
+} // namespace ndef_mfrc522


### PR DESCRIPTION
so disabling import by disabling serial print.

removed serial debug definition which identified a badly placed namespace bracket.